### PR TITLE
30 - fix: updated jq download url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM amazon/aws-cli:latest
-RUN curl -sL -o /usr/bin/jq https://stedolan.github.io/jq/download/linux64/jq
+RUN curl -sL -o /usr/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64
 RUN chmod +x /usr/bin/jq
 RUN curl -sL -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     curl -sL -o /usr/bin/aws-iam-authenticator $(curl -s https://api.github.com/repos/kubernetes-sigs/aws-iam-authenticator/releases/latest | jq -r ' .assets[] | select(.name | contains("linux_amd64")    )' | jq -r '.browser_download_url')  && \


### PR DESCRIPTION
Updates the download URL for `jq` to the latest as per https://jqlang.github.io/jq/download/