### PR TITLE
Add arch support to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM amazon/aws-cli:latest
 ARG TARGETARCH
 ARG JQ_VERSION=1.6
 ARG IAM_VERSION=0.6.12
+ENV TARGETARCH=${TARGETARCH}
 
 # Install system packages and jq first
 RUN dnf update -y && \
@@ -11,10 +12,13 @@ RUN dnf update -y && \
     chmod +x /usr/bin/jq
 
 # Install kubectl and aws-iam-authenticator
-RUN curl -sL -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl && \
-    curl -sL -o /usr/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${IAM_VERSION}/aws-iam-authenticator_${IAM_VERSION}_linux_${TARGETARCH} && \
-    chmod +x /usr/bin/aws-iam-authenticator && \
-    chmod +x /usr/bin/kubectl
+RUN export KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) && \
+    curl -sL -o /usr/bin/kubectl-${KUBECTL_VERSION} https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl && \
+    curl -sL -o /usr/bin/aws-iam-authenticator-${IAM_VERSION} https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${IAM_VERSION}/aws-iam-authenticator_${IAM_VERSION}_linux_${TARGETARCH} && \
+    chmod +x /usr/bin/aws-iam-authenticator-${IAM_VERSION} && \
+    chmod +x /usr/bin/kubectl-${KUBECTL_VERSION} && \
+    ln -s /usr/bin/aws-iam-authenticator-${IAM_VERSION} /usr/bin/aws-iam-authenticator && \
+    ln -s /usr/bin/kubectl-${KUBECTL_VERSION} /usr/bin/kubectl
 
 # Add checksum verification for security
 RUN echo "Checking versions of installed tools:" && \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: Deploy to EKS cluster
-      uses: kodermax/kubectl-aws-eks@main
+      uses: kodermax/kubectl-aws-eks@1
       env:
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -48,7 +48,7 @@ jobs:
         args: set image deployment/$ECR_REPOSITORY $ECR_REPOSITORY=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         
     - name: Verify deployment
-      uses: kodermax/kubectl-aws-eks@main
+      uses: kodermax/kubectl-aws-eks@1
       env:
         KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
       with:
@@ -87,7 +87,7 @@ By default, this action uses the latest stable version of kubectl. To use a spec
 
 ```yaml
 - name: Deploy to EKS cluster
-  uses: kodermax/kubectl-aws-eks@main
+  uses: kodermax/kubectl-aws-eks@1
   env:
     KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
     ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -104,7 +104,7 @@ By default, this action uses the latest version of aws-iam-authenticator. To use
 
 ```yaml
 - name: Deploy to EKS cluster
-  uses: kodermax/kubectl-aws-eks@main
+  uses: kodermax/kubectl-aws-eks@1
   env:
     KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
     ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -160,7 +160,7 @@ You can run any kubectl command by passing it as the `args` parameter:
 
 ```yaml
 - name: Get pod information
-  uses: kodermax/kubectl-aws-eks@main
+  uses: kodermax/kubectl-aws-eks@1
   env:
     KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
   with:
@@ -171,7 +171,7 @@ You can run any kubectl command by passing it as the `args` parameter:
 
 ```yaml
 - name: Apply Kubernetes manifests
-  uses: kodermax/kubectl-aws-eks@main
+  uses: kodermax/kubectl-aws-eks@1
   env:
     KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
   with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,25 +18,29 @@ if [ ! -s /tmp/config ]; then
     exit 1
 fi
 
-if [ -z ${KUBECTL_VERSION+x} ] ; then
-    echo "Using kubectl version: $(kubectl version --client 2>&1)"
-else
-    echo "Pulling kubectl for version $KUBECTL_VERSION"
-    rm -f /usr/bin/kubectl
-    curl -sL -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/"$KUBECTL_VERSION"/bin/linux/amd64/kubectl && \
-        chmod +x /usr/bin/kubectl
-    echo "Using kubectl version: $(kubectl version --client --short 2>&1)"
+if [ ! -z "${KUBECTL_VERSION}" ]; then
+    if [ ! -e /usr/bin/kubectl-${KUBECTL_VERSION} ]; then
+        echo "Pulling kubectl for version $KUBECTL_VERSION"
+        curl -sL -o /usr/bin/kubectl-${KUBECTL_VERSION} https://storage.googleapis.com/kubernetes-release/release/"$KUBECTL_VERSION"/bin/linux/$TARGETARCH/kubectl && \
+            chmod +x /usr/bin/kubectl-${KUBECTL_VERSION} && \
+            ln -f -s /usr/bin/kubectl-${KUBECTL_VERSION} /usr/bin/kubectl
+    else
+      ln -f -s /usr/bin/kubectl-${KUBECTL_VERSION} /usr/bin/kubectl
+    fi
 fi
+echo "Using kubectl version: $(kubectl version --client 2>&1)"
 
-if [ -z ${IAM_VERSION+x} ] ; then
-    echo "Using aws-iam-authenticator version: $(aws-iam-authenticator version 2>&1)"
-else
-    echo "Pulling aws-iam-authenticator for version $IAM_VERSION"
-    rm -f /usr/bin/aws-iam-authenticator
-    curl -sL -o /usr/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v"$IAM_VERSION"/aws-iam-authenticator_"$IAM_VERSION"_linux_amd64 && \
-    chmod +x /usr/bin/aws-iam-authenticator
-    echo "Using aws-iam-authenticator version: $(aws-iam-authenticator version 2>&1)"
+if [ ! -z "${IAM_VERSION}" ]; then
+    if [ ! -e /usr/bin/aws-iam-authenticator-${IAM_VERSION} ]; then
+        echo "Pulling aws-iam-authenticator for version $IAM_VERSION"
+        curl -sL -o /usr/bin/aws-iam-authenticator-${IAM_VERSION} https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v"$IAM_VERSION"/aws-iam-authenticator_"$IAM_VERSION"_linux_$TARGETARCH && \
+            chmod +x /usr/bin/aws-iam-authenticator-${IAM_VERSION} && \
+            ln -f -s /usr/bin/aws-iam-authenticator-${IAM_VERSION} /usr/bin/aws-iam-authenticator
+    else
+        ln -f -s /usr/bin/aws-iam-authenticator-${IAM_VERSION} /usr/bin/aws-iam-authenticator
+    fi
 fi
+echo "Using aws-iam-authenticator version: $(aws-iam-authenticator version 2>&1)"
 
 # Check if tools were successfully installed
 if ! command -v kubectl >/dev/null 2>&1; then


### PR DESCRIPTION
Missed adding arch support to entrypoint script
Track versions installed so we do not install duplicates

Change examples to not use @main but to use @1 instead, so people are using release versions by default when coping examples
